### PR TITLE
bulib additions: Add severity toggle, docs for google sheets import

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ _note: options marked with an asterisk ('*') are required_
 
 ## Example
 
-The following would be added to a secondary `custom.module.js` (or similarly named) file after the module is installed.
+The following would be added to a secondary `wrlc-announce-config.module.js` (or similarly named) file after the module is installed.
 
 This example uses Google Sheets as the source for the announcement data.
 
@@ -90,13 +90,13 @@ This example uses Google Sheets as the source for the announcement data.
 |id |show_banner|message_severity|message_text|message_link|
 |:--|:----------|:---------------|:-----------|:-----------|
 |0  | TRUE | info | This is the first message text | http://thelink.com/1 |
-|1  | FALSE| warn | An example of warning text | http://thelink.com/2 |
-|2  | TRUE | success | You're getting it! (Hopefully) | http://theotherlink.com/3 |
+|1  | FALSE| warn | An example of warning text | http://theotherlink.com/2 |
+|2  | TRUE | success | You're getting it! (Hopefully) | http://yetanotherlink.com/3 |
 |3  | TRUE | alert | If you're not, open up an issue and we'll help out! | https://github.com/wrlc-primo-dev/primo-explore-wrlc-announce/issues |
 
 2. Go to 'File > Publish to the Web'. Select the relevant sheet and 'Web Page', then click publish. Copy and paste the link it shows you to make sure it works.
 
-3. In your new `custom.module.js` file, set the `announceAPI` variable to match
+3. In your new `wrlc-announce-config.module.js` file, set the `announceAPI` variable to match
   `'https://spreadsheets.google.com/feeds/list/<SHEET_ID>/1/public/values?alt=json'`
   replacing `<SHEET_ID>` with what's matching from the link at the top of your browser:
   `https://docs.google.com/spreadsheets/d/<SHEET_ID>/edit`

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This example uses Google Sheets as the source for the announcement data.
       // - helper code for announcement banner ['wrlcAnnounce'] - //
       app.constant('announceConfig', {
 
-        // view/edit the values in the regular view by using the same 'id' (/feeds/list<ID>/1/public below) in the following: (docs.google.com/spreadsheets/d/<SHEET_ID>)
+        // view/edit the values in google spreadsheets regular view by using the same 'SHEET_ID' in the following: (docs.google.com/spreadsheets/d/<SHEET_ID>/edit)
         announceAPI: 'https://spreadsheets.google.com/feeds/list/1dhGFCdOYlEG-DxkNs5F94WnHEmEIyTllQKhhWWtmmIE/1/public/values?alt=json',
 
         // specify which of the N 'entries' (rows) you want the info for [defaulted to 0]
@@ -82,3 +82,21 @@ This example uses Google Sheets as the source for the announcement data.
       });
 
 ```
+
+## Setting up Google Sheets as the `announceAPI` data source
+
+1. Create a new google sheet with the following general format:
+
+|id |show_banner|message_severity|message_text|message_link|
+|:--|:----------|:---------------|:-----------|:-----------|
+|0  | TRUE | info | This is the first message text | http://thelink.com/1 |
+|1  | FALSE| warn | An example of warning text | http://thelink.com/2 |
+|2  | TRUE | success | You're getting it! (Hopefully) | http://theotherlink.com/3 |
+|3  | TRUE | alert | If you're not, open up an issue and we'll help out! | https://github.com/wrlc-primo-dev/primo-explore-wrlc-announce/issues |
+
+2. Go to 'File > Publish to the Web'. Select the relevant sheet and 'Web Page', then click publish. Copy and paste the link it shows you to make sure it works.
+
+3. In your new `custom.module.js` file, set the `announceAPI` variable to match
+  `'https://spreadsheets.google.com/feeds/list/<SHEET_ID>/1/public/values?alt=json'`
+  replacing `<SHEET_ID>` with what's matching from the link at the top of your browser:
+  `https://docs.google.com/spreadsheets/d/<SHEET_ID>/edit`

--- a/README.md
+++ b/README.md
@@ -32,13 +32,15 @@ Configure your API calls to retrieve announcements. `primo-explore-wrlc-announce
 
 | name | type | usage |
 |---|---|---|
-| `announceAPI` | string | A url that can be used to fetch your announcement data. |
+| `announceAPI`* | string | A url that can be used to fetch your announcement data. |
+| `getShow`* | function | A function that returns TRUE if you want to show your announcement banner. |
+| `getMessage`* | function | A function that returns the message text you want to display. |
+| `getLink`* | function | A function that returns a link you want to add the the Message text. |
 | `apiEntryNumber` | int | The id of the zero-indexed row you'd like information for (if you have multiple rows in your Google Sheet) |
-| `getData` | function | A function that gets at the main data element shared by each of the following |
+| `getData` | function | A function that gets at the main data element shared by each of the following (defaulted to the raw 'response'.)|
 | `getSeverity` | function | A function that returns the severity of the message (e.g. 'success', 'info', 'warn', 'alert') |
-| `getShow` | function | A function that returns TRUE if you want to show your announcement banner. |
-| `getMessage` | function | A function that returns the message text you want to display. |
-| `getLink` | function | A function that returns a link you want to add the the Message text. |
+
+_note: options marked with an asterisk ('*') are required_
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -28,32 +28,55 @@ Add `wrlcAnnounce` as a dependency for your custom module definition.
 ```js
 var app = angular.module('viewCustom', ['wrlcAnnounce'])
 ```
-Configure your API calls to retrieve announcements. primo-explore-wrlc-announce has the following configuration options
+Configure your API calls to retrieve announcements. `primo-explore-wrlc-announce` has the following configuration options
 
 | name | type | usage |
 |---|---|---|
 | `announceAPI` | string | A url that can be used to fetch your announcement data. |
+| `apiEntryNumber` | int | The id of the zero-indexed row you'd like information for (if you have multiple rows in your Google Sheet) |
+| `getData` | function | A function that gets at the main data element shared by each of the following |
+| `getSeverity` | function | A function that returns the severity of the message (e.g. 'success', 'info', 'warn', 'alert') |
 | `getShow` | function | A function that returns TRUE if you want to show your announcement banner. |
 | `getMessage` | function | A function that returns the message text you want to display. |
 | `getLink` | function | A function that returns a link you want to add the the Message text. |
 
 ## Example
 
-The following would be added to the custom.js file after the module installed. This example uses Google Sheets as the source for the announcement data.
+The following would be added to a secondary `custom.module.js` (or similarly named) file after the module is installed.
+
+This example uses Google Sheets as the source for the announcement data.
 
 ```js
-    var app = angular.module('viewCustom', ['angularLoad', 'wrlcAnnounce']);
-    
-    app.constant('announceConfig', {
-        announceAPI: 'https://spreadsheets.google.com/feeds/list/1ycVxLuY5LYwsFbGX-n_TlJPAF-wI73Lf_aJiZKzm0vI/1/public/values?alt=json',
-        getShow: function(response) {
-            return(response.data.feed.entry[0].gsx$show.$t);
+      //load app 'viewCustom' as a module with [] dependencies
+      var app = angular.module('viewCustom', ['angularLoad', 'wrlcAnnounce']);
+
+      // - helper code for announcement banner ['wrlcAnnounce'] - //
+      app.constant('announceConfig', {
+
+        // view/edit the values in the regular view by using the same 'id' (/feeds/list<ID>/1/public below) in the following: (docs.google.com/spreadsheets/d/<SHEET_ID>)
+        announceAPI: 'https://spreadsheets.google.com/feeds/list/1dhGFCdOYlEG-DxkNs5F94WnHEmEIyTllQKhhWWtmmIE/1/public/values?alt=json',
+
+        // specify which of the N 'entries' (rows) you want the info for [defaulted to 0]
+        apiEntryNumber: 0,
+
+        // get the main data object associated with your desired view
+        getData: function(response) {
+          return response.data.feed.entry[this.apiEntryNumber];
         },
-        getMessage: function(response) {
-            return(response.data.feed.entry[0].gsx$message.$t);
+
+        // obtain the specifically relevant parts of that data object
+        getShow: function(data) {
+          return data.gsx$showbanner.$t;
         },
-        getLink: function(response) {
-            return(response.data.feed.entry[0].gsx$link.$t);
+        getMessage: function(data) {
+          return data.gsx$messagetext.$t;
+        },
+        getLink: function(data) {
+          return data.gsx$messagelink.$t;
+        },
+        getSeverity: function(data) {
+          return data.gsx$messageseverity.$t;
         }
-    });
+      });
+
 ```

--- a/css/custom1.css
+++ b/css/custom1.css
@@ -25,3 +25,15 @@ prm-search-bar {
 #wrlc-announce-icon {
 	margin-right:12px;
 }
+
+.warn #wrlc-announce-banner {
+  background-color: lightyellow;
+}
+
+.success #wrlc-announce-banner {
+  background-color: lightgreen;
+}
+
+.alert #wrlc-announce-banner {
+  background-color: lightcoral;
+}

--- a/css/custom1.css
+++ b/css/custom1.css
@@ -22,18 +22,23 @@ prm-search-bar {
   height: 58.5px;
 }
 
-#wrlc-announce-icon {
-	margin-right:12px;
+#message {
+  margin-left: 12px;
+  margin-right: 12px;
 }
 
-.warn #wrlc-announce-banner {
-  background-color: lightyellow;
+#wrlc-announce-banner.warn  {
+  background: lightyellow !important;
 }
 
-.success #wrlc-announce-banner {
-  background-color: lightgreen;
+#wrlc-announce-banner.success {
+  background: mediumaquamarine !important;
 }
 
-.alert #wrlc-announce-banner {
-  background-color: lightcoral;
+#wrlc-announce-banner.alert {
+  background: lightcoral !important;
+}
+
+#wrlc-announce-banner.info {
+  background: lightblue !important;
 }

--- a/js/wrlc-announce.module.js
+++ b/js/wrlc-announce.module.js
@@ -3,17 +3,20 @@ angular.module('wrlcAnnounce', ['ngAnimate'])
 
 .component('prmSearchBarAfter', {
   template: `
-  <wrlc-announce ng-show="!$ctrl.dismissed" ng-if="$ctrl.show">
-    <div id="wrlc-announce-banner" class="layout-align-center-center layout-row flex">
-      <prm-icon icon-type="svg" svg-icon-set="action" icon-definition="ic_announcement_24px" id="wrlc-announce-icon"></prm-icon>
-      <span ng-if="$ctrl.link" id="message"><a href="{{$ctrl.link}}">{{ $ctrl.message }}</a></span>
-      <span ng-if="!$ctrl.link" ng-bind-html=$ctrl.message id="message"></span>
-      <button id="dismiss-announcement" area-label="dismiss announcement" type="button" ng-click="$ctrl.wrDismiss()"
+    <wrlc-announce ng-show="!$ctrl.dismissed" ng-if="$ctrl.show">
+      <div id="wrlc-announce-banner" class="layout-align-center-center layout-row flex {{$ctrl.severity}}">
+        <prm-icon ng-if="$ctrl.severity=='info'" icon-type="svg" svg-icon-set="action" icon-definition="ic_info_24px"></prm-icon>
+        <prm-icon ng-if="$ctrl.severity=='alert'" icon-type="svg" svg-icon-set="action" icon-definition="ic_announcement_24px"></prm-icon>
+        <prm-icon ng-if="$ctrl.severity=='warn'" icon-type="svg" svg-icon-set="action" icon-definition="ic_report_problem_24px"></prm-icon>
+        <prm-icon ng-if="$ctrl.severity=='success'" icon-type="svg" svg-icon-set="action" icon-definition="ic_check_circle_24px"></prm-icon>
+        <span ng-if="$ctrl.link" id="message"><a target="_blank" href="{{$ctrl.link}}">{{ $ctrl.message }}</a></span>
+        <span ng-if="!$ctrl.link" ng-bind-html=$ctrl.message id="message"></span>
+        <button id="dismiss-announcement" area-label="dismiss announcement" type="button" ng-click="$ctrl.wrDismiss()"
               class="dismiss-alert-button zero-margin md-button md-primoExplore-theme md-ink-ripple button-with-icon">
         <prm-icon icon-type="svg" svg-icon-set="navigation" icon-definition="ic_close_24px" class="material-icons gray"></prm-icon>
       </button>
-    </div>
-  </wrlc-announce>
+      </div>
+    </wrlc-announce>
   `,
   controller:
     function announceController(announceConfig, $http) {
@@ -23,15 +26,20 @@ angular.module('wrlcAnnounce', ['ngAnimate'])
       // interact with announceAPI helper to set values
       $http.get(config.announceAPI)
         .then(function(response){
-          // Test if we want to show the banner or not
-          self.show = (config.getShow(response) == "TRUE");
+          var data = config.getData(response);
 
-          // get message and link using configured functions
-          self.message = config.getMessage(response);
-          self.link = config.getLink(response);
+          // Test if we want to show the banner or not
+          var showFlagEnabled = config.getShow(data) == "TRUE";
+          var isEmptyMessage = config.getMessage.length == 0;
+          self.show = showFlagEnabled && !isEmptyMessage && !self.dismissed;
+
+          // get message info using configured functions
+          self.message = config.getMessage(data);
+          self.link = config.getLink(data);
+          self.severity = config.getSeverity(data);
         });
 
-      //respond to user exing out of function
+      //respond to user exing out of the banner
       self.wrDismiss = function() {
         self.dismissed = true;
       }

--- a/js/wrlc-announce.module.js
+++ b/js/wrlc-announce.module.js
@@ -1,44 +1,39 @@
-angular
-  // Define the module name
-  .module('wrlcAnnounce', ['ngAnimate'])
-    .component('prmSearchBarAfter', {
-        template: `
-            <wrlc-announce ng-show="!$ctrl.dismissed" ng-if="$ctrl.show">
-                <div id="wrlc-announce-banner" class="layout-align-center-center layout-row flex">
-                    <prm-icon icon-type="svg" svg-icon-set="action" icon-definition="ic_announcement_24px" id="wrlc-announce-icon"></prm-icon>
-                    <span ng-if="$ctrl.link" id="message"><a href="{{$ctrl.link}}">{{ $ctrl.message }}</a></span>
-	            <span ng-if="!$ctrl.link" ng-bind-html=$ctrl.message id="message"></span>
-	        <button id="dismiss-announcement" area-label="dismiss announcement" class="dismiss-alert-button zero-margin md-button md-primoExplore-theme md-ink-ripple button-with-icon" type="button" ng-click="$ctrl.wrDismiss()">
-	        	<prm-icon icon-type="svg" svg-icon-set="navigation" icon-definition="ic_close_24px" class="material-icons gray"></prm-icon>
-		</button>
-                </div>
-            </wrlc-announce>
-            `,
-        controller: 
-            function announceController(announceConfig, $http) {
-	    
+// specify module name and its dependency
+angular.module('wrlcAnnounce', ['ngAnimate'])
 
-                var self = this;
-                var config = announceConfig;
+.component('prmSearchBarAfter', {
+  template: `
+  <wrlc-announce ng-show="!$ctrl.dismissed" ng-if="$ctrl.show">
+    <div id="wrlc-announce-banner" class="layout-align-center-center layout-row flex">
+      <prm-icon icon-type="svg" svg-icon-set="action" icon-definition="ic_announcement_24px" id="wrlc-announce-icon"></prm-icon>
+      <span ng-if="$ctrl.link" id="message"><a href="{{$ctrl.link}}">{{ $ctrl.message }}</a></span>
+      <span ng-if="!$ctrl.link" ng-bind-html=$ctrl.message id="message"></span>
+      <button id="dismiss-announcement" area-label="dismiss announcement" type="button" ng-click="$ctrl.wrDismiss()"
+              class="dismiss-alert-button zero-margin md-button md-primoExplore-theme md-ink-ripple button-with-icon">
+        <prm-icon icon-type="svg" svg-icon-set="navigation" icon-definition="ic_close_24px" class="material-icons gray"></prm-icon>
+      </button>
+    </div>
+  </wrlc-announce>
+  `,
+  controller:
+    function announceController(announceConfig, $http) {
+      var self = this;
+      var config = announceConfig;
 
-                // get show announcement
-                $http.get(config.announceAPI)
-                    .then(function(response){
-                        // Test if we want to show the banner or not
-                        if (config.getShow(response) == "TRUE") {
-                            self.show = true;
-                        } else {
-                            self.show = false;
-                        }
-                        // get message and link using configured functions
-                        self.message = config.getMessage(response);
-                        self.link = config.getLink(response);
+      // interact with announceAPI helper to set values
+      $http.get(config.announceAPI)
+        .then(function(response){
+          // Test if we want to show the banner or not
+          self.show = (config.getShow(response) == "TRUE");
 
-                    });    
-	    self.wrDismiss = function() {
-	        self.dismissed = true;
-	    }
-            }
+          // get message and link using configured functions
+          self.message = config.getMessage(response);
+          self.link = config.getLink(response);
+        });
 
-
-    });
+      //respond to user exing out of function
+      self.wrDismiss = function() {
+        self.dismissed = true;
+      }
+    }
+});

--- a/js/wrlc-announce.module.js
+++ b/js/wrlc-announce.module.js
@@ -13,8 +13,8 @@ angular.module('wrlcAnnounce', ['ngAnimate'])
         <span ng-if="!$ctrl.link" ng-bind-html=$ctrl.message id="message"></span>
         <button id="dismiss-announcement" area-label="dismiss announcement" type="button" ng-click="$ctrl.wrDismiss()"
               class="dismiss-alert-button zero-margin md-button md-primoExplore-theme md-ink-ripple button-with-icon">
-        <prm-icon icon-type="svg" svg-icon-set="navigation" icon-definition="ic_close_24px" class="material-icons gray"></prm-icon>
-      </button>
+          <prm-icon icon-type="svg" svg-icon-set="navigation" icon-definition="ic_close_24px" class="material-icons gray"></prm-icon>
+        </button>
       </div>
     </wrlc-announce>
   `,
@@ -26,7 +26,7 @@ angular.module('wrlcAnnounce', ['ngAnimate'])
       // interact with announceAPI helper to set values
       $http.get(config.announceAPI)
         .then(function(response){
-          var data = config.getData(response);
+          var data = (config.getData)? config.getData(response) : response;
 
           // Test if we want to show the banner or not
           var showFlagEnabled = config.getShow(data) == "TRUE";
@@ -36,7 +36,7 @@ angular.module('wrlcAnnounce', ['ngAnimate'])
           // get message info using configured functions
           self.message = config.getMessage(data);
           self.link = config.getLink(data);
-          self.severity = config.getSeverity(data);
+          self.severity = (config.getSeverity)? config.getSeverity(data) : 'info';
         });
 
       //respond to user exing out of the banner


### PR DESCRIPTION
Resolves #7 

### Background
- first off, _thank you_ :tada: for your work with this! 
  - it really helped me understand how `primo-explore` works with npm and helped me to get my first assigned customization done much more quickly 
  - i forked it (instead of cloning it) to formally recognize that I was making the changes on behalf of [BU Libraries](http://www.bu.edu/library/).
- these changes came from a desire to:
  - manage multiple messages in that same google sheet for different scenarios/views
  - provide the user more context for the importance/type of announcement they were reading

### Screenshots

**Information**
![screenshot_info](https://user-images.githubusercontent.com/5565284/45386259-e7240780-b5e0-11e8-98b8-36d088b14c87.png)

**Warning**
![screenshot_warn](https://user-images.githubusercontent.com/5565284/45386281-fb680480-b5e0-11e8-992b-5b3c7c7e062a.png)

**Success**
![screenshot_success](https://user-images.githubusercontent.com/5565284/45386345-26eaef00-b5e1-11e8-8980-0aaf9196837f.png)

**Alert**
![screenshot_alert](https://user-images.githubusercontent.com/5565284/45386391-4124cd00-b5e1-11e8-8bff-0c2fb02eed5d.png)


### Description of Changes
- add a few additional (optional) configuration options
  - `apiEntryNumber`: in case you have multiple messages on the same GoogleSheet that you want to switch between more easily
  - `getSeverity`: alter the display (icon, background color) based on type of announcement
  - `getData`: reduces some of the code duplication/hassle with getting/changing the specific data from the announce request (very slightly) 
- add documentation around how to set up Google Sheets (answering #7 from before)
- assorted super small stuff
  - the link opens in a new tab
  - the default icon changed from `announcement` to `info` [material icons](https://material.io/tools/icons/?icon=info&style=baseline)
  - reformatted, commented, refactored a couple sections (spacing, naming, comments)

### Additional Notes
- compatibility: ensuring the update doesn't break existing consumers
  - I tried to ensure that any of the changes I made were backwards compatible (establishing smart defaults for what I'd added). 
  - I've tested locally (without `npm`) and everything seemed to work as it did
  - It's still likely worth some testing before/after publishing a new version on `npm`, and I'd be happy to coordinate that with you.
  - no dependencies or extra libraries were used (even the icons are from the same collection)
- if you'd like me to undo or adjust any parts of this or have any questions/better approaches, don't hesitate to say so.